### PR TITLE
support router introduced in tornado 4.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,8 @@ language: python
 python:
   - "2.7"
   - "3.5"
+  - "3.6"
+env:
+  - TORNADO_VERSION="==4.4.2"
+  - TORNADO_VERSION="==4.5.3"
 script: "./uranium test"

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,6 @@ from setuptools import setup, find_packages
 
 base = os.path.dirname(os.path.abspath(__file__))
 README_PATH = os.path.join(base, "README.rst")
-TORNADO_VERSION = os.environ.get("TORNADO_VERSION", "")
 
 is_release = False
 if "--release" in sys.argv:
@@ -14,7 +13,7 @@ if "--release" in sys.argv:
 
 install_requires = [
     'transmute-core',
-    'tornado' + TORNADO_VERSION,
+    'tornado',
 ]
 
 tests_require = []

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,7 @@ from setuptools import setup, find_packages
 
 base = os.path.dirname(os.path.abspath(__file__))
 README_PATH = os.path.join(base, "README.rst")
+TORNADO_VERSION = os.environ.get("TORNADO_VERSION", "")
 
 is_release = False
 if "--release" in sys.argv:
@@ -13,7 +14,7 @@ if "--release" in sys.argv:
 
 install_requires = [
     'transmute-core',
-    'tornado<=4.4.2'
+    'tornado' + TORNADO_VERSION,
 ]
 
 tests_require = []
@@ -45,6 +46,8 @@ setup(name='tornado-transmute',
           'Programming Language :: Python :: 3.2',
           'Programming Language :: Python :: 3.3',
           'Programming Language :: Python :: 3.4',
+          'Programming Language :: Python :: 3.5',
+          'Programming Language :: Python :: 3.6',
       ],
       tests_require=tests_require
 )

--- a/ubuild.py
+++ b/ubuild.py
@@ -3,6 +3,10 @@ import subprocess
 
 
 def main(build):
+    tornado_version = os.environ.get("TORNADO_VERSION")
+    if tornado_version:
+        build.packages.install("tornado", version=tornado_version)
+
     build.packages.install(".", develop=True)
 
 


### PR DESCRIPTION
tornado 4.5 introduces a new routing framework which replaces the handlers stored on the app object. this pr supports both the legacy approach as well as the new router.

ref: http://www.tornadoweb.org/en/stable/routing.html